### PR TITLE
Adding PID for translation

### DIFF
--- a/Rot_Test_PID_Bt.ino
+++ b/Rot_Test_PID_Bt.ino
@@ -14,15 +14,22 @@ String a;// esta variable guarda temporalmete lo que se recibe del serial
 String b;// esta variable guarda un substring
 String c;// esta variable guarda un substring
 String d;// esta variable guarda un substring
-int error;
-int previousError;
-float errorDot;
-float control;
-float k_P=1;// El coefficient del proportional  del angulo
-float k_D =0;// el coefficient de la derivada del angulo
+int error_Rot;
+int previousError_Rot;
+float errorDot_Rot;
+float control_Rot;
+int error_Pos;
+int previousError_Pos;
+float errorDot_Pos;
+float control_Pos;
+float k_P_Rot=1;// El coefficient del proportional  del angulo
+float k_D_Rot =0;// el coefficient de la derivada del angulo
+float k_P_Pos=1;// El coefficient del proportional del magnitude del error en position
+float k_D_Pos =0;// el coefficient de la derivada del magnitud del error en position
 int previousTime;
 int currentTime;// these two are needed to find the derivative of the error
-int errorDeadband=1;// the deadband makes sure that the system is not overcompensating for negligable error
+int errorDeadband_Rot=1;// the deadband makes sure that the system is not overcompensating for negligable error
+int errorDeadband_Pos=1;
 int Msg ;// this variable stores the message number so classify the first and second as coefficients
 
 
@@ -36,21 +43,31 @@ void loop() {
 
   if (Serial.available()){ //espera a detectar algo. 
 
-    if( Msg<2){
+    if( Msg<4){
        if(Msg=0){
         a = Serial.readString();
-        k_P = a.toFloat();
+        k_P_Rot = a.toFloat();
         Msg=1;
         
         }
        if(Msg=1){
         a = Serial.readString();
-        k_D = a.toFloat();
+        k_D_Rot = a.toFloat();
         Msg=2;
+        }
+       if(Msg=2){
+        a = Serial.readString();
+        k_P_Pos = a.toFloat();
+        Msg=3;
+        }
+     if(Msg=3){
+        a = Serial.readString();
+        k_D_Pos = a.toFloat();
+        Msg=4;
         }
 
   }
-    if( Msg<=2){
+    if( Msg>=4){
     a = Serial.readString();
     b= getValue(a,',',0);
     c= getValue(a,',',1);
@@ -67,19 +84,23 @@ void loop() {
    //y ahora usamos if statements para detectar si el comando es idéntico a uno de los que  
    //pusimos al principio
     currentTime= millis();
-     error= zeta-0 ;
-    errorDot =(error-previousError)/(currentTime-previousTime);
+     error_Rot= zeta-alpha ;
+     error_Pos= mag-0
+    errorDot_Rot =(error_Rot-previousError_Rot)/(currentTime-previousTime);
+    errorDot_Pos =(error_Pos-previousError_Pos)/(currentTime-previousTime);
     //Serial.println("detected ");
-    previousError= error;
+    previousError_Rot= error_Rot;
+   previousError_Pos= error_Pos;
     previousTime=currentTime;    
-    control = -k_P*error +k_D*errorDot;
-    if(abs(control)>abs(errorDeadband) && -abs(errorDeadband)> -abs(control)){
-    if (control<0){
-      pivotLeft(100,abs(control));
+    control_Rot = -k_P_Rot*error_Rot +k_D_Rot*errorDot_Rot;
+   control_Pos = -k_P_Pos*error_Pos +k_D*errorDot_Pos;
+    if(abs(control_Rot)>abs(errorDeadband_Rot) && -abs(errorDeadband_Rot)> -abs(control_Rot)){
+    if (control_Rot<0){
+      pivotLeft(100,abs(control_Rot));
       //Serial.println("left");
     }
-    if ( control> 0) {
-      pivotRight(100,abs(control));
+    if ( control_Rot> 0) {
+      pivotRight(100,abs(control_Rot));
       //Serial.println("right");
     }
     
@@ -88,6 +109,20 @@ void loop() {
   stopMotors();
    //delay(100);
     }
+   if(abs(control_Rot)<abs(errorDeadband)&& -abs(errorDeadband)< -abs(control_Rot)){
+    if(abs(control_Pos)>abs(errorDeadband_Pos) && -abs(errorDeadband_Pos)> -abs(control_Pos)){
+    if (control_Pos<0){
+      backward(100,abs(control_Pos));
+      //Serial.println("left");
+    }
+    if ( control_Pos> 0) {
+      forward(100,abs(control_Pos));
+      //Serial.println("right");
+    }
+    
+  stopMotors();
+    
+   }
   }
 }
   }


### PR DESCRIPTION
@rangerdawavs must check before committing. This patch adds two more coefficients which are used for the PID of the translation. Since the vehicle is able to point at the center, from any position moving towards the center is a straight line problem and can use the same PID. This also required  renaming existing variables for rot with the suffix Rot and adding new ones with the suffix Pos. One slightly related change made was fixing the variable error so it does take into account the desired angle. The position PID only goes into effect when the error_Rot is in the deadband_Rot and if the error_Pos is out of the deadband_Pos. Testing is required to see if certain values need to be eliminated such for example removing more than 180 in error_Rot